### PR TITLE
fix(api): Now correctly loads tables

### DIFF
--- a/jahs_bench/api.py
+++ b/jahs_bench/api.py
@@ -160,13 +160,12 @@ class Benchmark:
         self._call_fn = self._benchmark_surrogate
 
     def _load_table(self):
-        assert self.save_dir.exists() and self.save_dir.is_dir()
+        assert self.table_dir.exists() and self.table_dir.is_dir()
 
-        table_path = self.save_dir / self.task.value
+        table_path = self.table_dir / self.task.value
         table_names = ["train_set.pkl.gz", "valid_set.pkl.gz", "test_set.pkl.gz"]
-        tables = [pd.read_pickle(table_path / n) for n in table_names]
+        tables = (pd.read_pickle(table_path / n) for n in table_names)
         table = pd.concat(tables, axis=0)
-        del tables
 
         # level_0_cols = ["features", "labels"]
         features: list = joint_config_space.get_hyperparameter_names() + ["epoch"]


### PR DESCRIPTION
* Closes #16 

Also saves memory and speeds up loading by using an iterator instead of loading all tables into memory at once.

@NeoChaos12 note on the keyword `del`. It's un-intuitive but it actually just decrements the reference count on the object, it won't collect it until the garbage collector comes along. Doesn't really matter here but I've encountered bugs because of this so thought you should know about it.